### PR TITLE
Fix rust dep for nogui build

### DIFF
--- a/Source/Core/CMakeLists.txt
+++ b/Source/Core/CMakeLists.txt
@@ -30,3 +30,12 @@ endif()
 if (WIN32 AND ENABLE_AUTOUPDATE)
   add_subdirectory(WinUpdater)
 endif()
+
+# Build SlippiRustExtensions for DolphinQt and DolphinNoGui
+#
+#set(RUST_FEATURES "")
+#if(DIS_PLAYBACK)
+#    set(RUST_FEATURES "playback")
+#endif()
+
+corrosion_import_crate(MANIFEST_PATH ${CMAKE_SOURCE_DIR}/Externals/SlippiRustExtensions/Cargo.toml ${RUST_FEATURES})

--- a/Source/Core/DolphinNoGUI/CMakeLists.txt
+++ b/Source/Core/DolphinNoGUI/CMakeLists.txt
@@ -26,7 +26,8 @@ set_target_properties(dolphin-nogui PROPERTIES OUTPUT_NAME dolphin-emu-nogui)
 
 target_link_libraries(dolphin-nogui
 PUBLIC
-	z
+  slippi-rust-extensions
+  z
 PRIVATE
   core
   uicommon
@@ -54,4 +55,3 @@ endif()
 
 set(CPACK_PACKAGE_EXECUTABLES ${CPACK_PACKAGE_EXECUTABLES} dolphin-nogui)
 install(TARGETS dolphin-nogui RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
-

--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -582,16 +582,6 @@ if(GETTEXT_MSGFMT_EXECUTABLE)
   endforeach()
 endif()
 
-# Link SlippiRustExtensions in.
-#
-# (This doesn't feel perfect here, but truth be told I can't think offhand of
-# a better location for it at the moment.)
-#set(RUST_FEATURES "")
-#if(DIS_PLAYBACK)
-#    set(RUST_FEATURES "playback")
-#endif()
-
-corrosion_import_crate(MANIFEST_PATH ${CMAKE_SOURCE_DIR}/Externals/SlippiRustExtensions/Cargo.toml ${RUST_FEATURES})
 target_link_libraries(dolphin-emu PUBLIC slippi-rust-extensions)
 
 if(APPLE)

--- a/build-mac.sh
+++ b/build-mac.sh
@@ -2,7 +2,7 @@
 # build-mac.sh
 
 QT_BREW_PATH=$(brew --prefix qt@6)
-CMAKE_FLAGS="-DQT_DIR=${QT_BREW_PATH}/lib/cmake/Qt6 -DENABLE_NOGUI=false"
+CMAKE_FLAGS="-DQT_DIR=${QT_BREW_PATH}/lib/cmake/Qt6"
 
 export LIBRARY_PATH=$LIBRARY_PATH:/usr/local/lib:/usr/lib/
 
@@ -21,8 +21,8 @@ then
 fi
 
 # Move into the build directory, run CMake, and compile the project
-mkdir -p build
-pushd build
+BUILD_DIR=build
+mkdir -p $BUILD_DIR && pushd $BUILD_DIR
 cmake ${CMAKE_FLAGS} ..
 cmake --build . --target dolphin-emu -- -j$(sysctl -n hw.ncpu)
 popd

--- a/build-mac.sh
+++ b/build-mac.sh
@@ -2,7 +2,7 @@
 # build-mac.sh
 
 QT_BREW_PATH=$(brew --prefix qt@6)
-CMAKE_FLAGS="-DQT_DIR=${QT_BREW_PATH}/lib/cmake/Qt6"
+CMAKE_FLAGS="-DQT_DIR=${QT_BREW_PATH}/lib/cmake/Qt6 -DENABLE_NOGUI=false"
 
 export LIBRARY_PATH=$LIBRARY_PATH:/usr/local/lib:/usr/lib/
 
@@ -21,8 +21,8 @@ then
 fi
 
 # Move into the build directory, run CMake, and compile the project
-BUILD_DIR=build
-mkdir -p $BUILD_DIR && pushd $BUILD_DIR
+mkdir -p build
+pushd build
 cmake ${CMAKE_FLAGS} ..
 cmake --build . --target dolphin-emu -- -j$(sysctl -n hw.ncpu)
 popd


### PR DESCRIPTION
Allows the nogui executable to be built again.

The main change is moving the rust build (`corrosion_import_crate`) out of `Source/Core/DolphinQt` and into `Source/Core` where it is visible to both `DolphinQt` and `DolphinNoGui`. Previously I tried including it in both, but this made rust unhappy.