### PR TITLE
chore: remove leftover check box in settings panel

### DIFF
--- a/Source/Core/DolphinQt/Settings/GeneralPane.cpp
+++ b/Source/Core/DolphinQt/Settings/GeneralPane.cpp
@@ -99,7 +99,6 @@ void GeneralPane::ConnectLayout()
 {
   connect(m_checkbox_dualcore, &QCheckBox::toggled, this, &GeneralPane::OnSaveConfig);
   connect(m_checkbox_cheats, &QCheckBox::toggled, this, &GeneralPane::OnSaveConfig);
-  connect(m_checkbox_default_boot_iso, &QCheckBox::toggled, this, &GeneralPane::OnSaveConfig);
   connect(m_checkbox_override_region_settings, &QCheckBox::stateChanged, this,
           &GeneralPane::OnSaveConfig);
   connect(m_checkbox_auto_disc_change, &QCheckBox::toggled, this, &GeneralPane::OnSaveConfig);
@@ -138,9 +137,6 @@ void GeneralPane::CreateBasic()
 
   m_checkbox_cheats = new QCheckBox(tr("Enable Cheats"));
   basic_group_layout->addWidget(m_checkbox_cheats);
-
-  m_checkbox_default_boot_iso = new QCheckBox(tr("Start Default ISO at launch"));
-  basic_group_layout->addWidget(m_checkbox_default_boot_iso);
 
   m_checkbox_override_region_settings = new QCheckBox(tr("Allow Mismatched Region Settings"));
   basic_group_layout->addWidget(m_checkbox_override_region_settings);

--- a/Source/Core/DolphinQt/Settings/GeneralPane.h
+++ b/Source/Core/DolphinQt/Settings/GeneralPane.h
@@ -41,7 +41,6 @@ private:
   QComboBox* m_combobox_fallback_region;
   QCheckBox* m_checkbox_dualcore;
   QCheckBox* m_checkbox_cheats;
-  QCheckBox* m_checkbox_default_boot_iso;
   QCheckBox* m_checkbox_override_region_settings;
   QCheckBox* m_checkbox_auto_disc_change;
 #ifdef USE_DISCORD_PRESENCE


### PR DESCRIPTION
"Start default iso at launch" doesn't exist upstream and doesn't work on slippi, triggers OnSaveConfig on click but actually has no value saved. Setting an empty string on the path tab is what triggers boot on launch