### PR TITLE
Correctly set number of threads in build-mac.sh

### DIFF
--- a/build-mac.sh
+++ b/build-mac.sh
@@ -24,5 +24,5 @@ fi
 mkdir -p build
 pushd build
 cmake ${CMAKE_FLAGS} ..
-cmake --build . --target dolphin-emu -- -j$(nproc)
+cmake --build . --target dolphin-emu -- -j$(sysctl -n hw.ncpu)
 popd


### PR DESCRIPTION
The current value `$(nproc)` only works on Linux and defaults to empty string on macos, which results in unlimited paralellism and likely a system OOM.