### PR TITLE
fix(build): set correct codesigning target

### DIFF
--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -684,7 +684,7 @@ if(APPLE)
     #   POST_BUILD COMMAND
     #   /usr/bin/codesign -f -s "${MACOS_CODE_SIGNING_IDENTITY}" --deep --options=runtime --entitlements "${CMAKE_SOURCE_DIR}/Source/Core/DolphinQt/DolphinEmu.entitlements" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE}/${OUTPUT_NAME}.app" || true)
     add_custom_command(TARGET dolphin-emu POST_BUILD
-      COMMAND /usr/bin/codesign -f -s "${MACOS_CODE_SIGNING_IDENTITY}" --deep --options=runtime --entitlements "${CMAKE_SOURCE_DIR}/Source/Core/DolphinQt/DolphinEmu$<$<CONFIG:Debug>:Debug>.entitlements" "$<TARGET_BUNDLE_DIR:OUTPUT_NAME>")
+      COMMAND /usr/bin/codesign -f -s "${MACOS_CODE_SIGNING_IDENTITY}" --deep --options=runtime --entitlements "${CMAKE_SOURCE_DIR}/Source/Core/DolphinQt/DolphinEmu$<$<CONFIG:Debug>:Debug>.entitlements" "$<TARGET_BUNDLE_DIR:dolphin-emu>")
   endif()
 else()
   install(TARGETS dolphin-emu RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/build-mac.sh
+++ b/build-mac.sh
@@ -4,6 +4,12 @@
 QT_BREW_PATH=$(brew --prefix qt@6)
 CMAKE_FLAGS="-DQT_DIR=${QT_BREW_PATH}/lib/cmake/Qt6 -DENABLE_NOGUI=false"
 
+# For some reason the system xxhash library doesn't get properly linked,
+# at least on my M1. The clang command gets -lxxhash, but probably needs
+# -L/opt/homebrew/lib/ to actually find the library.
+if [[ $(arch) == 'arm64' ]]; then
+  CMAKE_FLAGS+=" -DUSE_SYSTEM_XXHASH=OFF"
+fi
 export LIBRARY_PATH=$LIBRARY_PATH:/usr/local/lib:/usr/lib/
 
 # Build type


### PR DESCRIPTION
A couple changes needed to get the `build-mac.sh` script working on my M1 machine.

The xxhash thing is unsatisfying but oh well.