### PR TITLE
Disable frame advance if facing a bot

### DIFF
--- a/Source/Core/Core/HW/EXI/EXI_DeviceSlippi.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceSlippi.cpp
@@ -1556,6 +1556,19 @@ void CEXISlippi::handleSendInputs(s32 frame, u8 delay, s32 checksum_frame, u32 c
   slippi_netplay->SendSlippiPad(std::move(pad));
 }
 
+bool CEXISlippi::isFacingBots()
+{
+  u8 remote_player_count = matchmaking->RemotePlayerCount();
+
+  // If the opponent is using the bot build, they will be running ahead of us.
+  for (int i = 0; i < remote_player_count; i++)
+  {
+    if (slippi_netplay->m_remote_dolphin_type[i] != SlippiNetplayClient::DolphinType::BOT)
+      return false;
+  }
+  return true;
+}
+
 void CEXISlippi::prepareOpponentInputs(s32 frame, bool should_skip)
 {
   m_read_queue.clear();
@@ -1575,10 +1588,10 @@ void CEXISlippi::prepareOpponentInputs(s32 frame, bool should_skip)
   {
     frame_result = 3;  // Indicates we have disconnected
   }
-  // else if (shouldAdvanceOnlineFrame(frame))
-  // {
-  //   frame_result = 4;
-  // }
+  else if (!isFacingBots() && shouldAdvanceOnlineFrame(frame))
+  {
+    frame_result = 4;
+  }
 
   m_read_queue.push_back(frame_result);  // Write out the control message value
 

--- a/Source/Core/Core/HW/EXI/EXI_DeviceSlippi.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceSlippi.cpp
@@ -1423,6 +1423,9 @@ bool CEXISlippi::shouldSkipOnlineFrame(s32 frame, s32 finalized_frame)
 
 bool CEXISlippi::shouldAdvanceOnlineFrame(s32 frame)
 {
+  if (opponentRunahead())
+     return false;
+
   // Logic below is used to test frame advance by forcing it more often
   // SConfig::GetInstance().m_EmulationSpeed = 0.5f;
   // if (frame > 120 && frame % 10 < 3)
@@ -1556,11 +1559,24 @@ void CEXISlippi::handleSendInputs(s32 frame, u8 delay, s32 checksum_frame, u32 c
   slippi_netplay->SendSlippiPad(std::move(pad));
 }
 
-bool CEXISlippi::isFacingBots()
+bool CEXISlippi::opponentRunahead()
 {
+  // Bot players might be running ahead to "donate" their delay frames to us.
+
+  // Only registered bot accounts are allowed to do this.
+  auto player_info = matchmaking->GetPlayerInfo();
+  for (int i = 0; i < player_info.size(); i++)
+  {
+    if (i == matchmaking->LocalPlayerIndex())
+      continue;
+
+    if (!player_info[i].is_bot)
+      return false;
+  }
+
+  // Now check whether the bot is actually using runahead.
   u8 remote_player_count = matchmaking->RemotePlayerCount();
 
-  // If the opponent is using the bot build, they will be running ahead of us.
   for (int i = 0; i < remote_player_count; i++)
   {
     if (slippi_netplay->m_remote_dolphin_type[i] != SlippiNetplayClient::DolphinType::BOT)
@@ -1588,7 +1604,7 @@ void CEXISlippi::prepareOpponentInputs(s32 frame, bool should_skip)
   {
     frame_result = 3;  // Indicates we have disconnected
   }
-  else if (!isFacingBots() && shouldAdvanceOnlineFrame(frame))
+  else if (shouldAdvanceOnlineFrame(frame))
   {
     frame_result = 4;
   }

--- a/Source/Core/Core/HW/EXI/EXI_DeviceSlippi.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceSlippi.cpp
@@ -1290,7 +1290,11 @@ void CEXISlippi::handleOnlineInputs(u8* payload)
     // Reset character selections such that they are cleared for next game
     local_selections.Reset();
     if (slippi_netplay)
+    {
       slippi_netplay->StartSlippiGame();
+
+      slippi_netplay->SendDolphinType();
+    }
   }
 
   if (isDisconnected())

--- a/Source/Core/Core/HW/EXI/EXI_DeviceSlippi.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceSlippi.cpp
@@ -1459,7 +1459,7 @@ bool CEXISlippi::shouldAdvanceOnlineFrame(s32 frame)
           std::min(-offset_us / (speed_up_frame_window * 16683.0f), 1.0f);
       deviation = frame_window_multiplier * max_speed_up_amount;
     }
-    else
+    else if (offset_us > 0)
     {
       // Here we are ahead, so let's slow down our instance
       float frame_window_multiplier =
@@ -1571,10 +1571,10 @@ void CEXISlippi::prepareOpponentInputs(s32 frame, bool should_skip)
   {
     frame_result = 3;  // Indicates we have disconnected
   }
-  else if (shouldAdvanceOnlineFrame(frame))
-  {
-    frame_result = 4;
-  }
+  // else if (shouldAdvanceOnlineFrame(frame))
+  // {
+  //   frame_result = 4;
+  // }
 
   m_read_queue.push_back(frame_result);  // Write out the control message value
 

--- a/Source/Core/Core/HW/EXI/EXI_DeviceSlippi.h
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceSlippi.h
@@ -211,7 +211,7 @@ private:
   void setMatchSelections(u8* payload);
   bool shouldSkipOnlineFrame(s32 frame, s32 finalized_frame);
   bool shouldAdvanceOnlineFrame(s32 frame);
-  bool isFacingBots();
+  bool opponentRunahead();
   void handleLogInRequest();
   void handleLogOutRequest();
   void prepareOnlineStatus();

--- a/Source/Core/Core/HW/EXI/EXI_DeviceSlippi.h
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceSlippi.h
@@ -211,6 +211,7 @@ private:
   void setMatchSelections(u8* payload);
   bool shouldSkipOnlineFrame(s32 frame, s32 finalized_frame);
   bool shouldAdvanceOnlineFrame(s32 frame);
+  bool isFacingBots();
   void handleLogInRequest();
   void handleLogOutRequest();
   void prepareOnlineStatus();

--- a/Source/Core/Core/NetPlayProto.h
+++ b/Source/Core/Core/NetPlayProto.h
@@ -161,6 +161,7 @@ enum class MessageID : u8
   SLIPPI_CHAT_MESSAGE = 0x84,
   SLIPPI_COMPLETE_STEP = 0x85,
   SLIPPI_SYNCED_STATE = 0x86,
+  SLIPPI_DOLPHIN_TYPE = 0x8F,
 
   GolfRequest = 0x90,
   GolfSwitch = 0x91,

--- a/Source/Core/Core/Slippi/SlippiMatchmaking.cpp
+++ b/Source/Core/Core/Slippi/SlippiMatchmaking.cpp
@@ -540,6 +540,7 @@ void SlippiMatchmaking::handleMatchmaking()
       player_info.display_name = el.value("displayName", "");
       player_info.connect_code = el.value("connectCode", "");
       player_info.port = el.value("port", 0);
+      player_info.is_bot = el.value("isBot", false);
       if (el["chatMessages"].is_array())
       {
         player_info.chat_messages = el.value("chatMessages", m_user->GetDefaultChatMessages());

--- a/Source/Core/Core/Slippi/SlippiNetplay.cpp
+++ b/Source/Core/Core/Slippi/SlippiNetplay.cpp
@@ -84,6 +84,7 @@ SlippiNetplayClient::SlippiNetplayClient(std::vector<std::string> addrs, std::ve
     this->last_frame_timing[i] = FrameTiming();
     this->ping_us[i] = 0;
     this->last_frame_acked[i] = 0;
+    this->m_remote_dolphin_type[i] = DolphinType::STANDARD;
   }
 
   SLIPPI_NETPLAY = std::move(this);
@@ -524,6 +525,36 @@ unsigned int SlippiNetplayClient::OnData(sf::Packet& packet, ENetPeer* peer)
     //          results.fighters[1].current_health);
 
     remote_sync_states[p_idx] = results;
+  }
+  break;
+
+  case NetPlay::MessageID::SLIPPI_DOLPHIN_TYPE:
+  {
+    u8 packet_player_port;
+    if (!(packet >> packet_player_port))
+    {
+      ERROR_LOG_FMT(SLIPPI_ONLINE, "Netplay packet too small to read player index");
+      break;
+    }
+    u8 p_idx = PlayerIdxFromPort(packet_player_port);
+    if (p_idx >= m_remote_player_count)
+    {
+      ERROR_LOG_FMT(SLIPPI_ONLINE, "Got packet with invalid player idx {}", p_idx);
+      break;
+    }
+    u8 dolphin_type;
+    if (!(packet >> dolphin_type))
+    {
+      ERROR_LOG_FMT(SLIPPI_ONLINE, "Netplay packet too small to read dolphin type");
+      break;
+    }
+    INFO_LOG_FMT(SLIPPI_ONLINE, "Received dolphin type from opponent {}: {}", p_idx, dolphin_type);
+    DolphinType dolphin_type_enum = static_cast<DolphinType>(dolphin_type);
+    if (dolphin_type_enum != m_remote_dolphin_type[p_idx])
+    {
+      WARN_LOG_FMT(SLIPPI_ONLINE, "Dolphin type changed for player {}: {}", p_idx, dolphin_type);
+    }
+    m_remote_dolphin_type[p_idx] = dolphin_type_enum;
   }
   break;
 
@@ -1204,6 +1235,20 @@ void SlippiNetplayClient::SendSyncedGameState(SlippiSyncedGameState& s)
     *spac << s.fighters[i].current_health;
   }
   SendAsync(std::move(spac));
+}
+
+void SlippiNetplayClient::SendDolphinType()
+{
+  if (m_sent_dolphin_type)
+    return;
+
+  auto spac = std::make_unique<sf::Packet>();
+  *spac << static_cast<u8>(NetPlay::MessageID::SLIPPI_DOLPHIN_TYPE);
+  *spac << this->m_player_idx;
+  *spac << static_cast<u8>(DolphinType::HUMAN_VS_BOT);
+  SendAsync(std::move(spac));
+
+  m_sent_dolphin_type = true;
 }
 
 bool SlippiNetplayClient::GetGamePrepResults(u8 step_idx, SlippiGamePrepStepResults& res)

--- a/Source/Core/Core/Slippi/SlippiNetplay.h
+++ b/Source/Core/Core/Slippi/SlippiNetplay.h
@@ -181,6 +181,7 @@ public:
   void SetMatchSelections(SlippiPlayerSelections& s);
   void SendGamePrepStep(SlippiGamePrepStepResults& s);
   void SendSyncedGameState(SlippiSyncedGameState& s);
+  void SendDolphinType();
   bool GetGamePrepResults(u8 step_idx, SlippiGamePrepStepResults& res);
   std::unique_ptr<SlippiRemotePadOutput> GetFakePadOutput(int frame);
   std::unique_ptr<SlippiRemotePadOutput> GetSlippiRemotePad(int index, int max_frame_count);
@@ -199,6 +200,16 @@ public:
   std::unique_ptr<SlippiPlayerSelections> remote_chat_message_selection =
       nullptr;  // most recent chat message player selection (message + player index)
   u8 remote_sent_chat_message_id = 0;  // most recent chat message id that current player sent
+
+  enum class DolphinType
+  {
+    STANDARD,
+    BOT,
+    HUMAN_VS_BOT,
+  };
+
+  DolphinType m_remote_dolphin_type[SLIPPI_REMOTE_PLAYER_MAX];
+  bool m_sent_dolphin_type = false;
 
 protected:
   struct

--- a/Source/Core/Core/Slippi/SlippiUser.h
+++ b/Source/Core/Core/Slippi/SlippiUser.h
@@ -31,6 +31,8 @@ public:
     int port;
 
     std::vector<std::string> chat_messages;
+
+    bool is_bot = false;
   };
 
   SlippiUser(uintptr_t rs_exi_device_ptr);


### PR DESCRIPTION
The purpose of this PR is to allow bots to run ahead faster than realtime and thus "donate" their delay frames to a human opponent. The corresponding bot-dolphin is at https://github.com/vladfi1/dolphin/tree/online-bot.

I've included a handshake so that bot accounts can decide whether or not they actually want to run ahead. However, maybe it's fine to remove and just let any bot-side regular dolphin handle the time syncing (needs testing).