### PR TITLE
Fix Mainline Softlock on Rollbacks

### DIFF
--- a/Source/Core/Core/Slippi/SlippiSavestate.cpp
+++ b/Source/Core/Core/Slippi/SlippiSavestate.cpp
@@ -96,6 +96,9 @@ void SlippiSavestate::initBackupLocs()
       {0x804d77bc, 0x4},   // ???
       {0x804de7f0, 0x10},  // ???
 
+      // XFB Status
+      {0x804C1D7C, 0x4}
+
       // Camera Blocks, Temporarily added here
       //{0x80452c7c, 0x2B0}, // Cam Block 1, including gaps
       //{0x806e516c, 0xA8},  // Cam Block 2, including gaps

--- a/Source/Core/Core/Slippi/SlippiSavestate.cpp
+++ b/Source/Core/Core/Slippi/SlippiSavestate.cpp
@@ -96,8 +96,8 @@ void SlippiSavestate::initBackupLocs()
       {0x804d77bc, 0x4},   // ???
       {0x804de7f0, 0x10},  // ???
 
-      // XFB Status
-      {0x804C1D7C, 0x4}
+      // XFB / VI Memory
+      {0x804c0980, 0x15F8},
 
       // Camera Blocks, Temporarily added here
       //{0x80452c7c, 0x2B0}, // Cam Block 1, including gaps


### PR DESCRIPTION
Sometimes when connection conditions were poor or if you got really unlucky, mainline could softlock. This was one of the big blockers for us recommending it for more people.

I asked @sadkellz for help with this issue and together we were able to solve it pretty quickly. I had an inkling that it was due to some video interface values being saved and restored that shouldn't be and kellz helped find the addresses as well as test it.