### PR TITLE
Link against `Qt6::GuiPrivate` to resolve qpa/qplatformnativeinterface.h: No such file or directory

### DIFF
--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 
-find_package(Qt6 REQUIRED COMPONENTS Core Gui Widgets Svg)
+find_package(Qt6 REQUIRED COMPONENTS Core Gui GuiPrivate Widgets Svg)
 message(STATUS "Found Qt version ${Qt6_VERSION}")
 
 set_property(TARGET Qt6::Core PROPERTY INTERFACE_COMPILE_FEATURES "")
@@ -432,6 +432,7 @@ PRIVATE
 target_link_libraries(dolphin-emu
 PRIVATE
   core
+  Qt6::GuiPrivate
   Qt6::Widgets
   uicommon
   imgui


### PR DESCRIPTION
Trying to build without linking `Qt6::GuiPrivate` results in the following error:
```
  /home/trstruth/projects/dolphin/Source/Core/DolphinQt/MainWindow.cpp:34:10: fatal error:
  qpa/qplatformnativeinterface.h: No such file or directory
     34 | #include <qpa/qplatformnativeinterface.h>
        |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

I was able to resolve this with the diff in the PR, but CMake emits this new warning:
```
  CMake Warning at /usr/lib/cmake/Qt6/QtPublicDependencyHelpers.cmake:335 (message):
    This project is using headers of the GuiPrivate module and will therefore
    be tied to this specific Qt module build version.  Running this project
    against other versions of the Qt modules may crash at any arbitrary point.
    This is not a bug, but a result of using Qt internals.  You have been
    warned!

    You can disable this warning by setting QT_NO_PRIVATE_MODULE_WARNING to ON.
  Call Stack (most recent call first):
    /usr/lib/cmake/Qt6GuiPrivate/Qt6GuiPrivateConfig.cmake:58
  (_qt_internal_show_private_module_warning)
    /usr/lib/cmake/Qt6/Qt6Config.cmake:247 (find_package)
    Source/Core/DolphinQt/CMakeLists.txt:17 (find_package)
```

I'm unable to evaluate if this is a problem for the maintainers, but just wanted to share this as it was preventing me from building from source on my machine

```
                  -`                     trstruth@venus
                 .o+`                    --------------
                `ooo/                    OS: Arch Linux x86_64
               `+oooo:                   Kernel: Linux 6.18.2-arch2-1
              `+oooooo:                  Uptime: 3 hours, 1 min
              -+oooooo+:                 Packages: 725 (pacman)
            `/:-:++oooo+:                Shell: bash 5.3.9
           `/++++/+++++++:               Display (BNQ7FC7): 1920x1080 in 24", 240 Hz [External]
          `/++++++++++++++:              Display (XG32UCWG): 3840x2160 @ 1.25x in 32", 144 Hz [External]
         `/+++ooooooooooooo/`            Display (T27hv-20): 1440x2560 in 27", 75 Hz [External]
        ./ooosssso++osssssso+`           WM: Hyprland 0.52.2 (Wayland)
       .oossssso-````/ossssss+`          Cursor: Adwaita
      -osssssso.      :ssssssso.         Terminal: tmux 3.6a
     :osssssss/        osssso+++.        CPU: 12th Gen Intel(R) Core(TM) i9-12900K (24) @ 5.20 GHz
    /ossssssss/        +ssssooo/-        GPU: NVIDIA GeForce RTX 3080 [Discrete]
  `/ossssso+/:-        -:/+osssso+-      Memory: 4.17 GiB / 31.15 GiB (13%)
 `+sso+:-`                 `.-/+oso:     Swap: Disabled
`++:.                           `-/+/    Disk (/): 49.64 GiB / 1.73 TiB (3%) - ext4
.`                                 `/    Local IP (eno1): 192.168.1.151/24
                                         Locale: en_US.UTF-8
```