### PR TITLE
ci: fix macOS issues

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -262,7 +262,7 @@ jobs:
             artifact_name: mainline-macOS-playback
             build_config: playback
     name: "macOS ${{ matrix.build_type }}"
-    runs-on: macos-14
+    runs-on: macos-15-intel
     steps:
       - name: "Checkout"
         uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -262,7 +262,7 @@ jobs:
             artifact_name: mainline-macOS-playback
             build_config: playback
     name: "macOS ${{ matrix.build_type }}"
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
       - name: "Checkout"
         uses: actions/checkout@v4

--- a/build-mac.sh
+++ b/build-mac.sh
@@ -2,7 +2,7 @@
 # build-mac.sh
 
 QT_BREW_PATH=$(brew --prefix qt@6)
-CMAKE_FLAGS="-DQT_DIR=${QT_BREW_PATH}/lib/cmake/Qt6 -DENABLE_NOGUI=false"
+CMAKE_FLAGS="-DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DQT_DIR=${QT_BREW_PATH}/lib/cmake/Qt6 -DENABLE_NOGUI=false"
 
 # For some reason the system xxhash library doesn't get properly linked,
 # at least on my M1. The clang command gets -lxxhash, but probably needs


### PR DESCRIPTION
- update to macos-15-intel runners (last time intel runners will be available)
- allow old 3.5 cmake policy (work is being done by upstream to fix this)
- builds still run on macOS 14