### PR TITLE
Upstream libfmt >=11.0 fix; remove deprecated `localtime`

### DIFF
--- a/Source/Core/AudioCommon/AudioCommon.cpp
+++ b/Source/Core/AudioCommon/AudioCommon.cpp
@@ -15,6 +15,7 @@
 #include "AudioCommon/PulseAudioStream.h"
 #include "AudioCommon/WASAPIStream.h"
 #include "Common/FileUtil.h"
+#include "Common/TimeUtil.h"
 #include "Common/Logging/Log.h"
 #include "Core/Config/MainSettings.h"
 #include "Core/ConfigManager.h"
@@ -215,11 +216,14 @@ void StartAudioDump(Core::System& system)
   SoundStream* sound_stream = system.GetSoundStream();
 
   std::time_t start_time = std::time(nullptr);
+  const auto local_time = Common::LocalTime(start_time);
+  if (!local_time)
+    return;
 
   std::string path_prefix = File::GetUserPath(D_DUMPAUDIO_IDX) + SConfig::GetInstance().GetGameID();
 
   std::string base_name =
-      fmt::format("{}_{:%Y-%m-%d_%H-%M-%S}", path_prefix, fmt::localtime(start_time));
+      fmt::format("{}_{:%Y-%m-%d_%H-%M-%S}", path_prefix, *local_time);
 
   const std::string audio_file_name_dtk = fmt::format("{}_dtkdump.wav", base_name);
   const std::string audio_file_name_dsp = fmt::format("{}_dspdump.wav", base_name);

--- a/Source/Core/Common/FatFsUtil.cpp
+++ b/Source/Core/Common/FatFsUtil.cpp
@@ -25,6 +25,7 @@
 #include "Common/Logging/Log.h"
 #include "Common/ScopeGuard.h"
 #include "Common/StringUtil.h"
+#include "Common/TimeUtil.h"
 
 #include "Core/Config/MainSettings.h"
 
@@ -95,7 +96,7 @@ int SDCardDiskIOCtl(File::IOFile* image, u8 pdrv, u8 cmd, void* buff)
 u32 GetSystemTimeFAT()
 {
   const std::time_t time = std::time(nullptr);
-  std::tm tm = std::tm tm = *Common::LocalTime(time);
+  std::tm tm = *Common::LocalTime(time);
 
   DWORD fattime = 0;
   fattime |= (tm.tm_year - 80) << 25;

--- a/Source/Core/Common/FatFsUtil.cpp
+++ b/Source/Core/Common/FatFsUtil.cpp
@@ -95,12 +95,7 @@ int SDCardDiskIOCtl(File::IOFile* image, u8 pdrv, u8 cmd, void* buff)
 u32 GetSystemTimeFAT()
 {
   const std::time_t time = std::time(nullptr);
-  std::tm tm;
-#ifdef _WIN32
-  localtime_s(&tm, &time);
-#else
-  localtime_r(&time, &tm);
-#endif
+  std::tm tm = std::tm tm = *Common::LocalTime(time);
 
   DWORD fattime = 0;
   fattime |= (tm.tm_year - 80) << 25;

--- a/Source/Core/Common/SettingsHandler.cpp
+++ b/Source/Core/Common/SettingsHandler.cpp
@@ -123,6 +123,6 @@ std::string SettingsWriter::GenerateSerialNumber()
   // Must be 9 characters at most; otherwise the serial number will be rejected by SDK libraries,
   // as there is a check to ensure the string length is strictly lower than 10.
   // 3 for %j, 2 for %H, 2 for %M, 2 for %S.
-  return fmt::format("{:%j%H%M%S}", fmt::localtime(t));
+  return fmt::format("{:09}", t % 1000000000);
 }
 }  // namespace Common

--- a/Source/Core/Common/TimeUtil.cpp
+++ b/Source/Core/Common/TimeUtil.cpp
@@ -8,7 +8,7 @@
 
 namespace Common
 {
-std::optional<std::tm> Localtime(std::time_t time)
+std::optional<std::tm> LocalTime(std::time_t time)
 {
   std::tm local_time;
 #ifdef _MSC_VER

--- a/Source/Core/Common/TimeUtil.h
+++ b/Source/Core/Common/TimeUtil.h
@@ -9,5 +9,5 @@
 namespace Common
 {
 // Threadsafe and error-checking variant of std::localtime()
-std::optional<std::tm> Localtime(std::time_t time);
+std::optional<std::tm> LocalTime(std::time_t time);
 }  // Namespace Common

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -8,6 +8,7 @@
 #include <cstring>
 #include <functional>
 #include <mutex>
+#include <optional>
 #include <queue>
 #include <utility>
 #include <variant>
@@ -33,6 +34,7 @@
 #include "Common/MsgHandler.h"
 #include "Common/ScopeGuard.h"
 #include "Common/StringUtil.h"
+#include "Common/TimeUtil.h"
 #include "Common/Thread.h"
 #include "Common/Version.h"
 
@@ -744,15 +746,19 @@ static std::string GenerateScreenshotFolderPath()
   return path;
 }
 
-static std::string GenerateScreenshotName()
+static std::optional<std::string> GenerateScreenshotName()
 {
   // append gameId, path only contains the folder here.
   const std::string path_prefix =
       GenerateScreenshotFolderPath() + SConfig::GetInstance().GetGameID();
 
   const std::time_t cur_time = std::time(nullptr);
+  const auto local_time = Common::LocalTime(cur_time);
+  if (!local_time)
+    return std::nullopt;
+
   const std::string base_name =
-      fmt::format("{}_{:%Y-%m-%d_%H-%M-%S}", path_prefix, fmt::localtime(cur_time));
+      fmt::format("{}_{:%Y-%m-%d_%H-%M-%S}", path_prefix, *local_time);
 
   // First try a filename without any suffixes, if already exists then append increasing numbers
   std::string name = fmt::format("{}.png", base_name);
@@ -773,7 +779,9 @@ void SaveScreenShot()
   // slippi change: end
 
   const Core::CPUThreadGuard guard(Core::System::GetInstance());
-  g_frame_dumper->SaveScreenshot(GenerateScreenshotName());
+  std::optional<std::string> name = GenerateScreenshotName();
+  if (name)
+    g_frame_dumper->SaveScreenshot(*name);
 }
 
 void SaveScreenShot(std::string_view name)

--- a/Source/Core/Core/NetworkCaptureLogger.cpp
+++ b/Source/Core/Core/NetworkCaptureLogger.cpp
@@ -16,6 +16,7 @@
 #include "Common/Network.h"
 #include "Common/PcapFile.h"
 #include "Common/ScopeGuard.h"
+#include "Common/TimeUtil.h"
 #include "Core/Config/MainSettings.h"
 #include "Core/ConfigManager.h"
 
@@ -82,7 +83,7 @@ PCAPSSLCaptureLogger::PCAPSSLCaptureLogger()
 {
   const std::string filepath =
       fmt::format("{}{} {:%Y-%m-%d %Hh%Mm%Ss}.pcap", File::GetUserPath(D_DUMPSSL_IDX),
-                  SConfig::GetInstance().GetGameID(), fmt::localtime(std::time(nullptr)));
+                  SConfig::GetInstance().GetGameID(), *Common::LocalTime(std::time(nullptr)));
   m_file = std::make_unique<Common::PCAP>(
       new File::IOFile(filepath, "wb", File::SharedAccess::Read), Common::PCAP::LinkType::Ethernet);
 }

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -290,7 +290,7 @@ static std::string SystemTimeAsDoubleToString(double time)
 {
   // revert adjustments from GetSystemTimeAsDouble() to get a normal Unix timestamp again
   const time_t seconds = static_cast<time_t>(time) + DOUBLE_TIME_OFFSET;
-  const auto local_time = Common::Localtime(seconds);
+  const auto local_time = Common::LocalTime(seconds);
   if (!local_time)
     return "";
 

--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -18,6 +18,7 @@ find_package(Qt6 REQUIRED COMPONENTS Core Gui Widgets Svg)
 
 if (Qt6_VERSION VERSION_GREATER_EQUAL 6.10.0)
   # GuiPrivate is needed to #include qplatformnativeinterface.h in MainWindow.cpp with Qt 6.10+.
+  set(QT_NO_PRIVATE_MODULE_WARNING ON)
   set(NEED_QT_GUI_PRIVATE_COMPONENT ON)
   find_package(Qt6 REQUIRED COMPONENTS GuiPrivate)
 endif()

--- a/Source/Core/VideoCommon/FrameDumpFFMpeg.cpp
+++ b/Source/Core/VideoCommon/FrameDumpFFMpeg.cpp
@@ -30,6 +30,7 @@ extern "C" {
 #include "Common/Logging/LogManager.h"
 #include "Common/MsgHandler.h"
 #include "Common/StringUtil.h"
+#include "Common/TimeUtil.h"
 
 #include "Core/Config/GraphicsSettings.h"
 #include "Core/Config/MainSettings.h"
@@ -127,8 +128,12 @@ std::string GetDumpPath(const std::string& extension, std::time_t time, u32 inde
   const std::string path_prefix =
       File::GetUserPath(D_DUMPFRAMES_IDX) + SConfig::GetInstance().GetGameID();
 
+  const auto local_time = Common::LocalTime(time);
+  if (!local_time)
+    return "";
+
   const std::string base_name =
-      fmt::format("{}_{:%Y-%m-%d_%H-%M-%S}_{}", path_prefix, fmt::localtime(time), index);
+      fmt::format("{}_{:%Y-%m-%d_%H-%M-%S}_{}", path_prefix, *local_time, index);
 
   const std::string path = fmt::format("{}.{}", base_name, extension);
 


### PR DESCRIPTION
Replace deprecated fmt::localtime with common::localtime for fmt 11
Remove guipriv warning text from Qt6.10