### PR TITLE
fix: don't append data to match reporter unless we're in netplay

### DIFF
--- a/Source/Core/Core/HW/EXI/EXI_DeviceSlippi.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceSlippi.cpp
@@ -3220,8 +3220,9 @@ void CEXISlippi::DMAWrite(u32 _uAddr, u32 _uSize)
     g_need_input_for_frame = true;
     SlippiSpectateServer::getInstance().startGame();
     SlippiSpectateServer::getInstance().write(&mem_ptr[0], receive_commands_len + 1);
-    slprs_exi_device_reporter_push_replay_data(slprs_exi_device_ptr, &mem_ptr[0],
-                                               receive_commands_len + 1);
+    if (slippi_netplay)
+      slprs_exi_device_reporter_push_replay_data(slprs_exi_device_ptr, &mem_ptr[0],
+                                                 receive_commands_len + 1);
   }
 
   if (byte == CMD_MENU_FRAME)
@@ -3256,8 +3257,9 @@ void CEXISlippi::DMAWrite(u32 _uAddr, u32 _uSize)
       writeToFileAsync(&mem_ptr[buf_loc], payload_len + 1, "close");
       SlippiSpectateServer::getInstance().write(&mem_ptr[buf_loc], payload_len + 1);
       SlippiSpectateServer::getInstance().endGame();
-      slprs_exi_device_reporter_push_replay_data(slprs_exi_device_ptr, &mem_ptr[buf_loc],
-                                                 payload_len + 1);
+      if (slippi_netplay)
+        slprs_exi_device_reporter_push_replay_data(slprs_exi_device_ptr, &mem_ptr[buf_loc],
+                                                   payload_len + 1);
       break;
     case CMD_PREPARE_REPLAY:
       prepareGameInfo(&mem_ptr[buf_loc + 1]);
@@ -3269,8 +3271,9 @@ void CEXISlippi::DMAWrite(u32 _uAddr, u32 _uSize)
       g_need_input_for_frame = true;
       writeToFileAsync(&mem_ptr[buf_loc], payload_len + 1, "");
       SlippiSpectateServer::getInstance().write(&mem_ptr[buf_loc], payload_len + 1);
-      slprs_exi_device_reporter_push_replay_data(slprs_exi_device_ptr, &mem_ptr[buf_loc],
-                                                 payload_len + 1);
+      if (slippi_netplay)
+        slprs_exi_device_reporter_push_replay_data(slprs_exi_device_ptr, &mem_ptr[buf_loc],
+                                                   payload_len + 1);
       break;
     case CMD_IS_STOCK_STEAL:
       prepareIsStockSteal(&mem_ptr[buf_loc + 1]);
@@ -3404,8 +3407,9 @@ void CEXISlippi::DMAWrite(u32 _uAddr, u32 _uSize)
     default:
       writeToFileAsync(&mem_ptr[buf_loc], payload_len + 1, "");
       SlippiSpectateServer::getInstance().write(&mem_ptr[buf_loc], payload_len + 1);
-      slprs_exi_device_reporter_push_replay_data(slprs_exi_device_ptr, &mem_ptr[buf_loc],
-                                                 payload_len + 1);
+      if (slippi_netplay)
+        slprs_exi_device_reporter_push_replay_data(slprs_exi_device_ptr, &mem_ptr[buf_loc],
+                                                   payload_len + 1);
       break;
     }
 


### PR DESCRIPTION
Avoids an unnecessary memory leak if playing locally in infinite time mode.