### PR TITLE
fix: unconditionally lock in ControllerInterface::UpdateInput

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/ControllerInterface.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/ControllerInterface.cpp
@@ -354,6 +354,9 @@ void ControllerInterface::UpdateInput()
     }
 
     tls_is_updating_devices = false;
+
+    // All needed inputs have been read.
+    g_need_input_for_frame = false;
   }
 
   if (devices_to_remove.size() > 0)
@@ -363,9 +366,6 @@ void ControllerInterface::UpdateInput()
                                  [device](const auto& d) { return d.lock().get() == device; });
     });
   }
-
-  // All needed inputs have been read.
-  g_need_input_for_frame = false;
 }
 
 void ControllerInterface::SetCurrentInputChannel(ciface::InputChannel input_channel)

--- a/Source/Core/InputCommon/ControllerInterface/ControllerInterface.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/ControllerInterface.cpp
@@ -320,7 +320,7 @@ void ControllerInterface::RemoveDevice(std::function<bool(const ciface::Core::De
     InvokeDevicesChangedCallbacks();
 }
 
-// Update input for all devices if lock can be acquired without waiting.
+// Update input for all devices.
 void ControllerInterface::UpdateInput()
 {
   // This should never happen
@@ -338,13 +338,7 @@ void ControllerInterface::UpdateInput()
   std::vector<std::weak_ptr<ciface::Core::Device>> devices_to_remove;
 
   {
-    // TODO: if we are an emulation input channel, we should probably always lock.
-    // Prefer outdated values over blocking UI or CPU thread (this avoids short but noticeable frame
-    // drops)
-    if (!m_devices_mutex.try_lock())
-      return;
-
-    std::lock_guard lk_devices(m_devices_mutex, std::adopt_lock);
+    std::lock_guard lk_devices(m_devices_mutex);
 
     tls_is_updating_devices = true;
 


### PR DESCRIPTION
The first commit is a cherry-pick of https://github.com/dolphin-emu/dolphin/pull/14632 from upstream. It ensures that the main emulator thread actually blocks on inputs each frame, even if another thread has the device lock. Without this, pipe inputs can get dropped even when blocking inputs is enabled.